### PR TITLE
Fix Checked C test dependencies in CMake file.

### DIFF
--- a/projects/checkedc-wrapper/CMakeLists.txt
+++ b/projects/checkedc-wrapper/CMakeLists.txt
@@ -28,11 +28,29 @@ if(EXISTS ${LLVM_MAIN_SRC_DIR}/projects/checkedc-wrapper/checkedc)
 
   list(APPEND CHECKEDC_TEST_DEPS
     clang clang-headers
+    clang-format
+    c-index-test diagtool
+    clang-tblgen
+    clang-offload-bundler
     )
+
+  if(CLANG_ENABLE_STATIC_ANALYZER)
+    list(APPEND CLANG_TEST_DEPS
+      clang-check
+      )
+  endif()
 
   set(CHECKEDC_TEST_PARAMS
     checkedc_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg
     )
+
+if( NOT CLANG_BUILT_STANDALONE )
+  list(APPEND CHECKEDC_TEST_DEPS
+    llvm-config
+    FileCheck count not
+    opt
+    )
+endif()
 
   add_custom_target(checkedc-test-depends DEPENDS ${CHECKEDC_TEST_DEPS})
 


### PR DESCRIPTION
I tried building the target that runs the Checked C tests in a clean object directory.   I had not built a target that runs other clang tests first.   I discovered that programs that the test infrastructure uses had not been built.  There were complaints from the test infrastructure as well about missing programs.

I have added the missing dependencies for building the programs to the  Checked C tests' CMakeLists.txt.   The dependencies are adapted from the clang tests' CMakeLists.txt.   The tests now run in a clean object directory.

