### PR TITLE
Excludes CheckedC samples dir from Checked C regression Tests

### DIFF
--- a/projects/checkedc-wrapper/lit.cfg
+++ b/projects/checkedc-wrapper/lit.cfg
@@ -49,7 +49,7 @@ config.suffixes = ['.c', '.cpp', '.m', '.mm', '.cu', '.ll', '.cl', '.s', '.S', '
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories. 
-config.excludes = ['spec', 'Inputs', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt']
+config.excludes = ['samples', 'spec', 'Inputs', 'CMakeLists.txt', 'README.txt', 'LICENSE.txt']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
This goes with Microsoft/checkedc#111

The regression tests will error without it.