### PR TITLE
Reduce programs built for Checked C tests.

### DIFF
--- a/projects/checkedc-wrapper/CMakeLists.txt
+++ b/projects/checkedc-wrapper/CMakeLists.txt
@@ -28,10 +28,6 @@ if(EXISTS ${LLVM_MAIN_SRC_DIR}/projects/checkedc-wrapper/checkedc)
 
   list(APPEND CHECKEDC_TEST_DEPS
     clang clang-headers
-    clang-format
-    c-index-test diagtool
-    clang-tblgen
-    clang-offload-bundler
     )
 
   if(CLANG_ENABLE_STATIC_ANALYZER)

--- a/projects/checkedc-wrapper/lit.cfg
+++ b/projects/checkedc-wrapper/lit.cfg
@@ -250,11 +250,6 @@ NoPostHyphenDot = r"(?!(-|\.))"
 NoPostBar = r"(?!(/|\\))"
 
 tool_patterns = [r"\bFileCheck\b",
-                 r"\bc-index-test\b",
-                 NoPreHyphenDot + r"\bclang-check\b" + NoPostHyphenDot,
-                 NoPreHyphenDot + r"\bclang-format\b" + NoPostHyphenDot,
-                 # FIXME: Some clang test uses opt?
-                 NoPreHyphenDot + r"\bopt\b" + NoPostBar + NoPostHyphenDot,
                  # Handle these specially as they are strings searched
                  # for during testing.
                  r"\| \bcount\b",


### PR DESCRIPTION
Change fadb75 added some missing programs to the dependencies for the
Checked C tests.  In fact, it added too many programs.  Some programs are not
needed by the tests.  Remove those programs to improve re-build times for
the Checked C tests.