### PR TITLE
Update Bug Tracker URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ endif()
 
 set(PACKAGE_NAME LLVM)
 set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
-set(PACKAGE_BUGREPORT "http://llvm.org/bugs/")
+set(PACKAGE_BUGREPORT "https://github.com/Microsoft/checkedc-clang/issues")
 
 set(BUG_REPORT_URL "${PACKAGE_BUGREPORT}" CACHE STRING
   "Default URL where bug reports are to be submitted.")


### PR DESCRIPTION
This is the PR to address https://github.com/Microsoft/checkedc-clang/issues/321

Unfortunately the BUG_REPORT_URL is cached, so you have to re-build your cmake dir for it to pick up the change, which is infuriating. 

Closes Microsoft/checkedc-clang#321