### PR TITLE
VS2017 installer part2

### DIFF
--- a/tools/msbuild/install.bat
+++ b/tools/msbuild/install.bat
@@ -47,6 +47,12 @@ IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
     SET D="%%i\Common7\IDE\VC\VCTargets\Platforms\%PLATFORM%\PlatformToolsets"
   )
 )
+REM On 32-bit Windows OSes before Windows 10, vswhere will be installed under %ProgramFiles%
+IF EXIST "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" (
+  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -version 15 -property installationPath`) DO (
+    SET D="%%i\Common7\IDE\VC\VCTargets\Platforms\%PLATFORM%\PlatformToolsets"
+  )
+)
 if EXIST %D% GOTO FOUND_V150
 
 GOTO PLATFORMLOOPHEAD

--- a/tools/msbuild/install.bat
+++ b/tools/msbuild/install.bat
@@ -43,13 +43,13 @@ IF EXIST %D% GOTO FOUND_V140
 REM MSBuild is now under the Visual Studio installation.  VSWhere is a new executable placed in a known
 REM location that can be used to find the VS installation, starting with VS 2017 SP1
 IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
-  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -version 15 -property installationPath`) DO (
+  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -version 15 -property installationPath`) DO (
     SET D="%%i\Common7\IDE\VC\VCTargets\Platforms\%PLATFORM%\PlatformToolsets"
   )
 )
 REM On 32-bit Windows OSes before Windows 10, vswhere will be installed under %ProgramFiles%
 IF EXIST "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" (
-  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -version 15 -property installationPath`) DO (
+  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -version 15 -property installationPath`) DO (
     SET D="%%i\Common7\IDE\VC\VCTargets\Platforms\%PLATFORM%\PlatformToolsets"
   )
 )

--- a/tools/msbuild/uninstall.bat
+++ b/tools/msbuild/uninstall.bat
@@ -73,6 +73,13 @@ IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
     SET D="%%i\Common7\IDE\VC\VCTargets\Platforms\%PLATFORM%\PlatformToolsets"
   )
 )
+
+REM On 32-bit Windows OSes before Windows 10, vswhere will be installed under %ProgramFiles%
+IF EXIST "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" (
+  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -version 15 -property installationPath`) DO (
+    SET D="%%i\Common7\IDE\VC\VCTargets\Platforms\%PLATFORM%\PlatformToolsets"
+  )
+)
 IF EXIST %D%\LLVM-vs2017 del %D%\LLVM-vs2017\toolset.props
 IF EXIST %D%\LLVM-vs2017 del %D%\LLVM-vs2017\toolset.targets
 IF EXIST %D%\LLVM-vs2017 rmdir %D%\LLVM-vs2017

--- a/tools/msbuild/uninstall.bat
+++ b/tools/msbuild/uninstall.bat
@@ -69,14 +69,14 @@ IF EXIST %D%\LLVM-vs2014_xp rmdir %D%\LLVM-vs2014_xp
 REM MSBuild is now under the Visual Studio installation.  VSWhere is a new executable placed in a known
 REM location that can be used to find the VS installation, starting with VS 2017 SP1
 IF EXIST "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" (
-  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -version 15 -property installationPath`) DO (
+  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -version 15 -property installationPath`) DO (
     SET D="%%i\Common7\IDE\VC\VCTargets\Platforms\%PLATFORM%\PlatformToolsets"
   )
 )
 
 REM On 32-bit Windows OSes before Windows 10, vswhere will be installed under %ProgramFiles%
 IF EXIST "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" (
-  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -version 15 -property installationPath`) DO (
+  FOR /f "usebackq delims=" %%i IN (`"%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -version 15 -property installationPath`) DO (
     SET D="%%i\Common7\IDE\VC\VCTargets\Platforms\%PLATFORM%\PlatformToolsets"
   )
 )


### PR DESCRIPTION
On 32-bit OSes before Windows 10, vswhere is placed under %ProgramFiles%, not %ProgramFiles(x86)%.   Add code to handle this situation.

Visual Studio allows side-by-side installations, including installations of different products (Community, Professional, and Enterprise) with the same version and the same product with the same version.

For now, just use the latest version of VS 2017 installed in the install and uninstall scripts, so we get predictable behavior.   Alternately, we could go ahead and update every single version of VS 2017 installed on the machine.  That seems a little aggressive, since if someone is using side-by-side versions of VS there may be a reason.


