### PR TITLE
Update location of registry key for Checked C LLVM/clang install.

### DIFF
--- a/tools/msbuild/Microsoft.Cpp.Win32.llvm.props.in
+++ b/tools/msbuild/Microsoft.Cpp.Win32.llvm.props.in
@@ -3,8 +3,8 @@
   <Import Project="$(VCTargetsPath)\Platforms\$(Platform)\PlatformToolsets\@VS_VERSION@\Toolset.props" Condition="Exists('$(VCTargetsPath)\Platforms\$(Platform)\PlatformToolsets\@VS_VERSION@\Toolset.props')"/>
 
   <PropertyGroup>
-    <LLVMInstallDir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\LLVM\@REG_KEY@)</LLVMInstallDir>
-    <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\LLVM\@REG_KEY@)</LLVMInstallDir>
+    <LLVMInstallDir>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\@REG_KEY@)</LLVMInstallDir>
+    <LLVMInstallDir Condition="'$(LLVMInstallDir)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\@REG_KEY@)</LLVMInstallDir>
     <ExecutablePath>$(LLVMInstallDir)\msbuild-bin;$(ExecutablePath)</ExecutablePath>
     <LibraryPath>$(LLVMInstallDir)\lib\clang\@LIB_PATH_VERSION@\lib\windows;$(LibraryPath)</LibraryPath>
   </PropertyGroup>


### PR DESCRIPTION
This addresses https://github.com/Microsoft/checkedc-clang/issues/442 (Visual Studio integration broken installer changes).    We install the Checked C version of LLVM in a different location than the main-line version, to avoid overwriting an existing installation.   I updated the organization name, which caused the location of a registry key used the MS Build property files to change.  Update the location of the registry key in those files.

