### PR TITLE
Fix lit testing using VS 2017.

### DIFF
--- a/utils/lit/lit/TestingConfig.py
+++ b/utils/lit/lit/TestingConfig.py
@@ -37,6 +37,7 @@ class TestingConfig:
             environment.update({
                     'INCLUDE' : os.environ.get('INCLUDE',''),
                     'PATHEXT' : os.environ.get('PATHEXT',''),
+                    'PROGRAMDATA' : os.environ.get('PROGRAMDATA',''),
                     'PYTHONUNBUFFERED' : '1',
                     'TEMP' : os.environ.get('TEMP',''),
                     'TMP' : os.environ.get('TMP',''),


### PR DESCRIPTION
When clang is run under the lit testing harness on a Windows machine with
only Visual Studio 2017 installed, clang can't find the VS install directory.  This
can cause tests that do linking to fail.   The lit scripts are filtering
out the ProgramData environment variable.   Clang is using a VS library
for finding the VS install location, and the library depends on the
ProgramData environment variable being set correctly.  The fix is to not
filter out the ProgramData variable.
