### PR TITLE
Workaround buggy behavior of isspace in ucrtbase.dll

### DIFF
--- a/lib/IR/AsmWriter.cpp
+++ b/lib/IR/AsmWriter.cpp
@@ -386,7 +386,10 @@ static void PrintCallingConv(unsigned cc, raw_ostream &Out) {
 void llvm::PrintEscapedString(StringRef Name, raw_ostream &Out) {
   for (unsigned i = 0, e = Name.size(); i != e; ++i) {
     unsigned char C = Name[i];
-    if (isprint(C) && C != '\\' && C != '"')
+    // Check for tab explicitly to handle buggy behavior
+    // in Windows 10 ucrtbase.dll, which regards tab as a printable
+    // character in version 10.0.17134.165.
+    if (isprint(C) && C != '\\' && C != '"' && C != '\t')
       Out << C;
     else
       Out << '\\' << hexdigit(C >> 4) << hexdigit(C & 0x0F);


### PR DESCRIPTION
Our release builds of clang started failing automated testing on Sunday evening.  The bug was obscure: some inline asm tests only in release builds on Windows stopped escaping tab characters for some reason.

I debugged the problem yesterday by tracing through clang.  I discovered that there's apparently a bug in a recently-updated version of the universal C runtime (ucrtbase.dll, version 10.0.17134.165).   It is now reporting tab as a printable character.  This caused LLVM's encoding of inline asm as strings to change.

The bug has already been reported: https://developercommunity.visualstudio.com/content/problem/297085/changing-result-of-isspacet.html..
