### PR TITLE
Run Checked C tests using llvm-lit from command shell.

### DIFF
--- a/projects/checkedc-wrapper/CMakeLists.txt
+++ b/projects/checkedc-wrapper/CMakeLists.txt
@@ -25,6 +25,8 @@ if(CHECKEDC_IN_TREE)
   configure_lit_site_cfg(
     ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
     ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+    MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
     )
 
   list(APPEND CHECKEDC_TEST_DEPS

--- a/projects/checkedc-wrapper/lit.cfg.py
+++ b/projects/checkedc-wrapper/lit.cfg.py
@@ -67,8 +67,7 @@ llvm_config.with_system_environment(
 tool_dirs = [config.clang_tools_dir, config.llvm_tools_dir]
 
 tools = [
-    'c-index-test', 'clang-check', 'clang-diff', 'clang-format', 'clang-tblgen',
-    'opt',
+    'clang-tblgen', 'opt',
     ToolSubst('%clang_extdef_map', command=FindTool(
         'clang-extdef-mapping'), unresolved='ignore'),
 ]


### PR DESCRIPTION
Fiix the generation of llvm-lit.py so that llvm-lit can be used to run Checked C tests in the Checked C repo from the command line. Several arguments were missing from configure_lit_site_cfg in the CmakeLists.txt file for the checkedc-wrapper directory.  This fixes Checked C issue https://github.com/Microsoft/checkedc/issues/340.

Also fix some warnings about missing tools when running the tests.  The tools are clang-specific test executables and tools not used by the Checked C repo tests.  Delete them from the list of required tools.
