### PR TITLE
Generate LLVM IR code for _MMSafe_ptr.

### DIFF
--- a/include/llvm/IR/DerivedTypes.h
+++ b/include/llvm/IR/DerivedTypes.h
@@ -219,6 +219,9 @@ public:
   StructType(const StructType &) = delete;
   StructType &operator=(const StructType &) = delete;
 
+  // Whether this struct is an instance  of a _MMSafe_ptr.
+  bool isMMSafePtr;
+
   /// This creates an identified struct.
   static StructType *create(LLVMContext &Context, StringRef Name);
   static StructType *create(LLVMContext &Context);
@@ -273,6 +276,9 @@ public:
 
   /// Return true if this is a named struct that has a non-empty name.
   bool hasName() const { return SymbolTableEntry != nullptr; }
+
+  /// Return true if this represents a _MMSafe_ptr<T>.
+  bool isMMSafePointerRep() const { return isMMSafePtr; }
 
   /// Return the name for this struct type if it has an identity.
   /// This may return an empty string for an unnamed struct type.  Do not call

--- a/include/llvm/IR/DerivedTypes.h
+++ b/include/llvm/IR/DerivedTypes.h
@@ -477,6 +477,11 @@ public:
   /// address space.
   static PointerType *get(Type *ElementType, unsigned AddressSpace);
 
+  /// This constructs a _MMSafe_ptr pointer to a struct object in a numbered 
+  /// address space.
+  static StructType *getMMSafePtr(Type *ElementType, LLVMContext &Context,
+                                  unsigned AddressSpace);
+
   /// This constructs a pointer to an object of the specified type in the
   /// generic address space (address space zero).
   static PointerType *getUnqual(Type *ElementType) {

--- a/include/llvm/IR/DerivedTypes.h
+++ b/include/llvm/IR/DerivedTypes.h
@@ -465,9 +465,12 @@ unsigned Type::getVectorNumElements() const {
 
 /// Class to represent pointers.
 class PointerType : public Type {
-  explicit PointerType(Type *ElType, unsigned AddrSpace);
+  explicit PointerType(Type *ElType, unsigned AddrSpace,
+                       bool isMMSafePtr = false);
 
   Type *PointeeTy;
+
+  bool isMMSafePtr;
 
 public:
   PointerType(const PointerType &) = delete;
@@ -489,6 +492,11 @@ public:
   }
 
   Type *getElementType() const { return PointeeTy; }
+
+  /// Return true if this is a _MMSafe_ptr<T> pointer.
+  bool isMMSafePointerTy() const {
+    return isMMSafePtr;
+  }
 
   /// Return true if the specified type is valid as a element type.
   static bool isValidElementType(Type *ElemTy);

--- a/include/llvm/IR/DerivedTypes.h
+++ b/include/llvm/IR/DerivedTypes.h
@@ -280,6 +280,13 @@ public:
   /// Return true if this represents a _MMSafe_ptr<T>.
   bool isMMSafePointerRep() const { return isMMSafePtr; }
 
+  /// Return the real pointer inside the struct representation of a _MMSafe_ptr.
+  PointerType *getInnerPtrFromMMSafePtrStruct() const {
+    assert(isMMSafePointerRep() &&
+        "This struct does not represent a MMSafe_ptr");
+    return cast<PointerType>(getElementType(0));
+  }
+
   /// Return the name for this struct type if it has an identity.
   /// This may return an empty string for an unnamed struct type.  Do not call
   /// this on an literal type.

--- a/include/llvm/IR/Instructions.h
+++ b/include/llvm/IR/Instructions.h
@@ -1189,13 +1189,18 @@ public:
 /// Represent an integer comparison operator.
 class ICmpInst: public CmpInst {
   void AssertOK() {
-    assert(isIntPredicate() &&
-           "Invalid ICmp predicate value");
-    assert(getOperand(0)->getType() == getOperand(1)->getType() &&
+    Type *LHS = getOperand(0)->getType();
+    Type *RHS = getOperand(1)->getType();
+    if (LHS->isMMSafePointerTy())
+      LHS = dyn_cast<StructType>(LHS)->getElementType(0);
+    if (RHS->isMMSafePointerTy())
+      RHS = dyn_cast<StructType>(LHS)->getElementType(0);
+
+    assert(isIntPredicate() && "Invalid ICmp predicate value");
+    assert(LHS == RHS &&
           "Both operands to ICmp instruction are not of the same type!");
     // Check that the operands are the right type
-    assert((getOperand(0)->getType()->isIntOrIntVectorTy() ||
-            getOperand(0)->getType()->isPtrOrPtrVectorTy()) &&
+    assert((LHS->isIntOrIntVectorTy() || LHS->isPtrOrPtrVectorTy()) &&
            "Invalid operand types for ICmp instruction");
   }
 

--- a/include/llvm/IR/Instructions.h
+++ b/include/llvm/IR/Instructions.h
@@ -1194,7 +1194,7 @@ class ICmpInst: public CmpInst {
     if (LHS->isMMSafePointerTy())
       LHS = dyn_cast<StructType>(LHS)->getElementType(0);
     if (RHS->isMMSafePointerTy())
-      RHS = dyn_cast<StructType>(LHS)->getElementType(0);
+      RHS = dyn_cast<StructType>(RHS)->getElementType(0);
 
     assert(isIntPredicate() && "Invalid ICmp predicate value");
     assert(LHS == RHS &&

--- a/include/llvm/IR/Type.h
+++ b/include/llvm/IR/Type.h
@@ -382,7 +382,7 @@ public:
   }
 
   /// Return the real pointer inside a MMSafe_ptr.
-  Type *getInnerPtrFromMMSafePtr() const;
+  PointerType *getInnerPtrFromMMSafePtr() const;
 
   /// Get the address space of this pointer or pointer vector type.
   inline unsigned getPointerAddressSpace() const;

--- a/include/llvm/IR/Type.h
+++ b/include/llvm/IR/Type.h
@@ -223,6 +223,9 @@ public:
   /// True if this is an instance of PointerType.
   bool isPointerTy() const { return getTypeID() == PointerTyID; }
 
+  /// True if this is a _MMSafe_ptr type.
+  bool isMMSafePointerTy() const;
+
   /// Return true if this is a pointer type or a vector of pointer types.
   bool isPtrOrPtrVectorTy() const { return getScalarType()->isPointerTy(); }
 

--- a/include/llvm/IR/Type.h
+++ b/include/llvm/IR/Type.h
@@ -381,6 +381,9 @@ public:
     return ContainedTys[0];
   }
 
+  /// Return the real pointer inside a MMSafe_ptr.
+  Type *getInnerPtrFromMMSafePtr() const;
+
   /// Get the address space of this pointer or pointer vector type.
   inline unsigned getPointerAddressSpace() const;
 

--- a/lib/IR/Type.cpp
+++ b/lib/IR/Type.cpp
@@ -114,7 +114,13 @@ bool Type::isEmptyTy() const {
 
 /// Testing if this represents a _MMSafe_ptr type.
 bool Type::isMMSafePointerTy() const {
-    return isStructTy() && dyn_cast<StructType>(this)->isMMSafePointerRep();
+    return isStructTy() && cast<StructType>(this)->isMMSafePointerRep();
+}
+
+/// Return the real pointer inside a MMSafe_ptr.
+Type *Type::getInnerPtrFromMMSafePtr() const {
+  assert(isMMSafePointerTy() && "This type is not a MMSafe_ptr");
+  return cast<StructType>(this)->getInnerPtrFromMMSafePtrStruct();
 }
 
 unsigned Type::getPrimitiveSizeInBits() const {

--- a/lib/IR/Type.cpp
+++ b/lib/IR/Type.cpp
@@ -114,7 +114,7 @@ bool Type::isEmptyTy() const {
 
 /// Testing if this represents a _MMSafe_ptr type.
 bool Type::isMMSafePointerTy() const {
-    return isStructTy() && cast<StructType>(this)->isMMSafePointerRep();
+  return isStructTy() && cast<StructType>(this)->isMMSafePointerRep();
 }
 
 /// Return the real pointer inside a MMSafe_ptr.

--- a/lib/IR/Type.cpp
+++ b/lib/IR/Type.cpp
@@ -670,10 +670,12 @@ StructType *PointerType::getMMSafePtr(Type *EltTy, LLVMContext &Context,
      : CImpl->ASPointerTypes[std::make_pair(EltTy, AddressSpace)];
 
   // Create a pointer to the pointee.
-  if (!PointeeEntry)
+  if (!PointeeEntry) {
     PointeeEntry = new (CImpl->TypeAllocator) PointerType(EltTy, AddressSpace);
-  PointeeEntry->dump();
+  }
 
+  PointeeEntry->isMMSafePtr = true;
+ 
   // Create an ID entry. 
   // Currently we hardcode the ID to be a 64-bit integer. This may affect
   // program's performance on a 32-bit platform. Maybe we should change it
@@ -683,8 +685,8 @@ StructType *PointerType::getMMSafePtr(Type *EltTy, LLVMContext &Context,
   return StructType::get(PointeeEntry, IDEntry);
 }
 
-PointerType::PointerType(Type *E, unsigned AddrSpace)
-  : Type(E->getContext(), PointerTyID), PointeeTy(E) {
+PointerType::PointerType(Type *E, unsigned AddrSpace, bool isMMSafePtrTy)
+  : Type(E->getContext(), PointerTyID), PointeeTy(E), isMMSafePtr(isMMSafePtrTy) {
   ContainedTys = &PointeeTy;
   NumContainedTys = 1;
   setSubclassData(AddrSpace);

--- a/lib/IR/Type.cpp
+++ b/lib/IR/Type.cpp
@@ -118,7 +118,7 @@ bool Type::isMMSafePointerTy() const {
 }
 
 /// Return the real pointer inside a MMSafe_ptr.
-Type *Type::getInnerPtrFromMMSafePtr() const {
+PointerType *Type::getInnerPtrFromMMSafePtr() const {
   assert(isMMSafePointerTy() && "This type is not a MMSafe_ptr");
   return cast<StructType>(this)->getInnerPtrFromMMSafePtrStruct();
 }


### PR DESCRIPTION
Summary of changes:
- when building a `_MMSafe_ptr<T>`, the compiler generates a `llvm::StructType` rather than a 
  `llvm::PointerType`.
- Added a method to check if a `llvm::PointerType` is a `_MMSafe_ptr`.
- Added a method to check if a `llvm::StructType` represents a `_MMSafe_ptr`.
- Added a method to check if a `llvm::Type` is a `_MMSafe_ptr`.
- Added methods to extract the inner pointer of a `_MMSafe_ptr` from a `llvm::Type` or 
  `llvm::StructType`.
- Added support for `_MMSafe_ptr` in `AssertOK()` of `ICmpInst`.